### PR TITLE
Fix reveal.js submodule inclusion

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "reveal.js"]
+	path = reveal.js
+	url = https://github.com/hakimel/reveal.js.git


### PR DESCRIPTION
reveal.js submodule was broken because `.gitmodules` was missing. This PR is fixing it…
