### PR TITLE
Enable serving from a subdirectory + GH Project Page instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,13 @@ Try the **[DEMO presentation](http://gh.tasmo.de/reveal-jekyll/)** (how to use J
 
 ### Get reveal-jekyll
 
-#### On GitHub:
+#### Hosting on Github Pages
 
 Follow the instructions on [get started with GitHub Pages](//pages.github.com/).
 
-##### For GitHub Pages
+To set up a [project site](https://help.github.com/articles/user-organization-and-project-pages/#project-pages), which will be accessible as `https://<yourname>.github.io/<projectname>`, simply fork [reveal-jekyll](//github.com/tasmo/reveal-jekyll) and name it whatever you like. Your site will be built from the `gh-pages` branch, so you should [set that as the default branch](https://help.github.com/articles/setting-the-default-branch/).
 
-Fork [reveal-jekyll](//github.com/tasmo/reveal-jekyll) and name it with your user or organisation name like `<yourname>.github.io`.
-
-You can also host as a project page ([read more in the official docs](https://help.github.com/articles/user-organization-and-project-pages/#project-pages)), which allows you to have as many sites as you like:
-
-- Fork this repo with a name like `mytalk`
-- Rather than master branch, you'll be using the `gh-pages` branch. It's the same as the master branch, just with different demo slides.
-- To avoid confusion, set `gh-pages` as the default branch in your Github project settings, and delete the master branch.
+If you want to instead set up a user or organization site, which will be accessible as `https://<yourname>.github.io/`, name your fork with your user or organisation name like `<yourname>.github.io`. In this case your site will build off the master branch.
 
 ##### For an Existing Repository
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Follow the instructions on [get started with GitHub Pages](//pages.github.com/).
 
 Fork [reveal-jekyll](//github.com/tasmo/reveal-jekyll) and name it with your user or organisation name like `<yourname>.github.io`.
 
+You can also host as a [project page](https://help.github.com/articles/user-organization-and-project-pages/#project-pages):
+
+- Clone this repo with a name like `mytalk`
+- Delete the `gh-pages` branch, create a new `gh-pages` branch off of `master`, and set `gh-pages` as the default branch. You can do all this through the Github web UI (TODO: details)
+- Set `baseurl` to `/mytalk` in `_config.yml`. This makes sure all the asset links work.
+
 ##### For an Existing Repository
 
 - clone your repository

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Follow the instructions on [get started with GitHub Pages](//pages.github.com/).
 
 Fork [reveal-jekyll](//github.com/tasmo/reveal-jekyll) and name it with your user or organisation name like `<yourname>.github.io`.
 
-You can also host as a [project page](https://help.github.com/articles/user-organization-and-project-pages/#project-pages):
+You can also host as a project page ([read more in the official docs](https://help.github.com/articles/user-organization-and-project-pages/#project-pages)), which allows you to have as many sites as you like:
 
-- Clone this repo with a name like `mytalk`
-- Delete the `gh-pages` branch, create a new `gh-pages` branch off of `master`, and set `gh-pages` as the default branch. You can do all this through the Github web UI (TODO: details)
-- Set `baseurl` to `/mytalk` in `_config.yml`. This makes sure all the asset links work.
+- Fork this repo with a name like `mytalk`
+- Rather than master branch, you'll be using the `gh-pages` branch. It's the same as the master branch, just with different demo slides.
+- To avoid confusion, set `gh-pages` as the default branch in your Github project settings, and delete the master branch.
 
 ##### For an Existing Repository
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,7 @@
 timezone:    Europe/Berlin
 future:      false
+# Set baseurl to the base path of the site eg "/mytalk"
+baseurl:     ""
 # The allowed values are 'rouge', 'pygments' or null.
 highlighter: rouge
 # markdown - Valid options are [ maruku | rdiscount | kramdown | redcarpet ]

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,9 +10,9 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-<link rel="stylesheet" href="/assets/css/style.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/style.css">
 <!-- jQuery -->
-<script src="/assets/js/jquery-1.11.1.min.js"></script>
+<script src="{{ site.baseurl }}/assets/js/jquery-1.11.1.min.js"></script>
 
 <!-- If the query includes 'print-pdf', include the PDF print sheet -->
 <script>
@@ -20,11 +20,11 @@
 		var link = document.createElement( 'link' );
 		link.rel = 'stylesheet';
 		link.type = 'text/css';
-		link.href = '/reveal.js/css/print/pdf.css';
+		link.href = '{{ site.baseurl }}/reveal.js/css/print/pdf.css';
 		document.getElementsByTagName( 'head' )[0].appendChild( link );
 	}
 </script>
 
 <!--[if lt IE 9]>
-<script src="{{ site.github.url }}/reveal.js/lib/js/html5shiv.js"></script>
+<script src="{{ site.baseurl }}/reveal.js/lib/js/html5shiv.js"></script>
 <![endif]-->

--- a/_includes/script.html
+++ b/_includes/script.html
@@ -1,8 +1,9 @@
-<script src="/reveal.js/lib/js/head.min.js"></script>
-<script src="/reveal.js/js/reveal.js"></script>
+<script src="{{ site.baseurl }}/reveal.js/lib/js/head.min.js"></script>
+<script src="{{ site.baseurl }}/reveal.js/js/reveal.js"></script>
 
 <!-- reveal.js init -->
 <script>
+  var baseUrl = "{{ site.baseurl }}"
   // Full list of configuration options available here:
   // https://github.com/hakimel/reveal.js#configuration
   Reveal.initialize({
@@ -17,19 +18,19 @@
     // Optional libraries used to extend on reveal.js
     dependencies: [
       // Cross-browser shim that fully implements classList - https://github.com/eligrey/classList.js/
-      { src: '/reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } },
+      { src: baseUrl + '/reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } },
 
       // Zoom in and out with Alt+click
-      { src: '/reveal.js/plugin/zoom-js/zoom.js', async: true },
+      { src: baseUrl + '/reveal.js/plugin/zoom-js/zoom.js', async: true },
 
       // Speaker notes
-      { src: '/reveal.js/plugin/notes/notes.js', async: true },
+      { src: baseUrl + '/reveal.js/plugin/notes/notes.js', async: true },
 
       // Remote control your reveal.js presentation using a touch device
-      //{ src: '/reveal.js/plugin/remotes/remotes.js', async: true, condition: function() { return !!document.body.classList; } },
+      //{ src: baseUrl + '/reveal.js/plugin/remotes/remotes.js', async: true, condition: function() { return !!document.body.classList; } },
 
       // MathJax
-      { src: '/reveal.js/plugin/math/math.js', async: true }
+      { src: baseUrl + '/reveal.js/plugin/math/math.js', async: true }
     ]
   });
 


### PR DESCRIPTION
Hi, thanks for making this, very useful!

I want to be able to host talks as Github [Project Pages](https://help.github.com/articles/user-organization-and-project-pages/#project-pages), so I made all the asset URLs sensitive to [site.baseurl](https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/). You can leave it unset, or an empty string, to keep the current output, or set it to eg `/mytalk`.

It's possible I missed an asset link somewhere but I didn't see any breakage.

Let me know what you think!