### PR TITLE
Add missing doc about baseurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ Try the **[DEMO presentation](http://gh.tasmo.de/reveal-jekyll/)** (how to use J
 
 Follow the instructions on [get started with GitHub Pages](//pages.github.com/).
 
+##### As a User or Organization Site
+
 To set up a user or organization site `https://<yourname>.github.io/`, fork [reveal-jekyll](//github.com/tasmo/reveal-jekyll) and name your fork with your user or organisation name like `<yourname>.github.io`. Your site will build off the master branch.
+
+##### As a Project Site
 
 To set up a [project site](https://help.github.com/articles/user-organization-and-project-pages/#project-pages) `https://<yourname>.github.io/<projectname>`:
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ Try the **[DEMO presentation](http://gh.tasmo.de/reveal-jekyll/)** (how to use J
 
 Follow the instructions on [get started with GitHub Pages](//pages.github.com/).
 
-To set up a [project site](https://help.github.com/articles/user-organization-and-project-pages/#project-pages), which will be accessible as `https://<yourname>.github.io/<projectname>`, simply fork [reveal-jekyll](//github.com/tasmo/reveal-jekyll) and name it whatever you like. Your site will be built from the `gh-pages` branch, so you should [set that as the default branch](https://help.github.com/articles/setting-the-default-branch/).
+To set up a user or organization site `https://<yourname>.github.io/`, fork [reveal-jekyll](//github.com/tasmo/reveal-jekyll) and name your fork with your user or organisation name like `<yourname>.github.io`. Your site will build off the master branch.
 
-If you want to instead set up a user or organization site, which will be accessible as `https://<yourname>.github.io/`, name your fork with your user or organisation name like `<yourname>.github.io`. In this case your site will build off the master branch.
+To set up a [project site](https://help.github.com/articles/user-organization-and-project-pages/#project-pages) `https://<yourname>.github.io/<projectname>`:
+
+ - Fork as above, but name your fork with whatever `<projectname>` you want.
+ - Your site will build from the `gh-pages` branch, so you should [set that as the default branch](https://help.github.com/articles/setting-the-default-branch/).
+ - In [_config.yml](./_config.yml) in your `gh-pages` branch, change `baseurl: ""` to `baseurl: /<projectname`. This is [needed](https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/) to construct asset include and internal link URLs correctly when you are serving your site from a non-root path.
 
 ##### For an Existing Repository
 


### PR DESCRIPTION
I realized I didn't mention that it's necessary to set `baseurl` when creating a project site, which was the whole point. Oops!